### PR TITLE
Mobile Safari long-press & localStorage-fallback hotfix (v0.14.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,10 @@ Not a traditional game-as-product, but a protocol-as-game:
   - Rationale: Keeps animation synchronized with deterministic game state
   - See: [checkRapid()](src/core.js#L138-L151)
 
+- Game Surface Owns Touch Gestures: Long-press gameplay zones must suppress browser-native selection/callout/scroll gestures at both CSS and event-listener boundaries
+  - Rationale: Mobile Safari can otherwise treat a long tap as text selection or callout instead of the game action; touch listeners that call `preventDefault()` must not be passive
+  - Pattern: Scope suppression to the board/card surface, keep the state machine unchanged, and avoid global overrides that break form controls or overlays
+
 - Move Encoding: Game actions serialized as base64-encoded integer arrays for compactness
   - Rationale: Reduces localStorage size and P2P bandwidth
   - See: [getBase64FromArray()](src/core.js#L103-L105)
@@ -223,6 +227,10 @@ Not a traditional game-as-product, but a protocol-as-game:
 - Idempotent Migration: Relay migration runs on every load without persisting until user action
   - Rationale: localStorage is source of truth only when it differs from defaults; migration is cheap and deterministic
   - Pattern: `load()` transforms data, `save()` happens only on explicit `set()`/`update()`
+
+- LocalStorage as Cache: Client persistence must degrade to in-memory stores when localStorage is unavailable, full, private-mode restricted, or contains invalid JSON
+  - Rationale: Mobile Safari can throw on storage reads/writes; gameplay must continue because local persistence is not part of deterministic validation
+  - Pattern: Catch storage failures at persistence boundaries, keep reactive store updates synchronous, and reuse safe JSON loaders for custom migrations
 
 ### Shared Package Principles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,93 +1,62 @@
 # Changelog
 
+## 0.14.3 Mobile Safari Hotfix
+
+- `Reliability`: Board/card long-press surfaces now explicitly disable native selection/callout gestures and cancel touch defaults so iOS long taps remain gameplay actions
+- `Reliability`: localStorage reads and writes now fail soft so unavailable, full, private-mode restricted, or corrupt browser storage cannot block gameplay state updates such as energy drain after moves
+- `Dependencies`: Refreshed the root package lock metadata for the 0.14.3 release and preserved npm's optional peer placeholder for `svelte-check`'s nested `fdir` dependency
+- `Developer Experience`: Added Node test coverage for localStorage fallback behavior and leaderboard protocol helpers so `npm test` and `npm test --workspaces` have passing validation paths
+
 ## 0.14.2 Dependency Lock Refresh
 
-### Dependencies
-
-- `Vite 8 / Svelte Tooling`: Regenerated `package-lock.json` from the upgraded `package.json` dependency set so clean `npm install` resolves `@sveltejs/vite-plugin-svelte@7.1.2` with `vite@8.0.13` instead of the stale Vite 7 tree
-
-### P2P
-
-- `Relay Rotation`: Removed the `use-all-relays` localStorage debug flag; browser clients always use relay rotation gating
-
-### Validation
-
-- `Validation Domain Module`: Kept replay validation in the `src/validation.js` domain module as the single source for record replay validation and input sanitizers, with isolated initial store state for parallel replay checks
-- `Record Validator CLI`: Added `npm run validate-records` for replay-validating leaderboard record JSON from a file path or stdin
-- `Headless Node Validation`: Leaderboard nodes now replay-validate inbound and persisted records instead of trusting received data
-- `Bootstrap Data Cleanup`: Removed invalid `vggjj` highCombo record whose replay value is 3, not the persisted 303
+- `Dependencies`: Regenerated `package-lock.json` from the upgraded `package.json` dependency set so clean `npm install` resolves `@sveltejs/vite-plugin-svelte@7.1.2` with `vite@8.0.13` instead of the stale Vite 7 tree
+- `P2P`: Removed the `use-all-relays` localStorage debug flag; browser clients always use relay rotation gating
+- `Validation`: Kept replay validation in `src/validation.js` as the single source for record replay validation and input sanitizers, with isolated initial store state for parallel replay checks
+- `Validation`: Added `npm run validate-records` for replay-validating leaderboard record JSON from a file path or stdin
+- `Validation`: Leaderboard nodes now replay-validate inbound and persisted records instead of trusting received data
+- `Validation`: Removed invalid `vggjj` highCombo record whose replay value is 3, not the persisted 303
 
 ## 0.14.1 Second Default Relay
 
-### P2P Infrastructure
+- `P2P Infrastructure`: Added `r2.digifall.app` to `DEFAULT_RELAYS`, giving clients and nodes a second built-in relay path for better network resilience
+- `P2P Infrastructure`: Bumped `@digifall/leaderboard` to 1.1.1 alongside the app version
+- `P2P Infrastructure`: Refreshed tracked leaderboard node data for bootstrap/backup continuity
+- `CI`: Deploy workflow now uses Node.js 24 with latest checkout/setup-node actions so `npm ci` runs under npm 11, matching the lockfile-generating local toolchain and avoiding npm 10 optional peer lockfile drift
+- `Context`: Removed rolling completed-work history from durable agent protocol; completed delivery history now belongs in this changelog per ABC context split
 
-- `Second Default Relay`: Added `r2.digifall.app` to `DEFAULT_RELAYS`, giving clients and nodes a second built-in relay path for better network resilience
-- `Leaderboard Package`: Bumped `@digifall/leaderboard` to 1.1.1 alongside the app version
-- `Bootstrap Data`: Refreshed tracked leaderboard node data for bootstrap/backup continuity
+## 0.14.0 Bump Deps + New Default Relay
 
-### CI
-
-- `Node 24 GitHub Actions`: Deploy workflow now uses Node.js 24 with latest checkout/setup-node actions so `npm ci` runs under npm 11, matching the lockfile-generating local toolchain and avoiding npm 10 optional peer lockfile drift
-
-### Context
-
-- `AGENTS.md Change History Removal`: Removed rolling completed-work history from durable agent protocol; completed delivery history now belongs in this changelog per ABC context split
-
-## 0.14.0 Bumd Deps + New Default Relay
-
-### Leaderboard Protocol
-
-- `@llblab/uniqueue API Compatibility`: `LeaderboardCore` now reads queue snapshots through a compatibility helper, supporting current `snapshot()` and older iterable/data-based Uniqueue instances
-- `@llblab/uniqueue 1.4`: Adapted `LeaderboardCore` to documented `snapshot()` and `get()` APIs instead of private `.data` / `.indexes` internals
-- `Headless Node Startup`: Fixed persisted leaderboard loading after dependency upgrades
-- `Record Insertion`: Preserved top-N behavior by treating self-evicted low-priority records as no-op updates
-
-### Relay Deployment
-
-- `CI Node Baseline`: GitHub Pages deploy now uses Node.js 22; `package.json` and lockfile declare `node >=22`; lockfile includes npm 10-compatible optional peer entries
-- `Stylelint Peer Resolution`: Overrode `stylelint-order` to a Stylelint 17-compatible version and narrowed lint globs to source/html inputs so generated `dist/` assets are not linted
-- `Self-Contained Relay Scripts`: Inlined the needed shell helpers into both relay lifecycle scripts so one-file `curl` installs do not depend on local or remote helper scripts
-- `Node Runtime Check`: Relay deployment now verifies both Node.js 22+ and npm, installing NodeSource Node.js when a distro provides node without npm
-- `RPM Package Managers`: Fedora/RHEL/CentOS deployment now supports both `dnf` and `yum`, with optional EPEL, certbot-nginx, and SELinux utility fallbacks
-- `Systemd Runtime Path`: Relay service now uses the resolved absolute npm binary instead of relying on `which npm` during unit generation
-- `Privilege Drop`: Temporary relay smoke test now uses `runuser` before falling back to `sudo`
-- `Relay Undeploy`: Refactored removal into safer idempotent steps with explicit confirmation, safe app-directory deletion guard, nginx reload validation, and shared helpers
+- `Leaderboard Protocol`: `LeaderboardCore` now reads queue snapshots through a compatibility helper, supporting current `snapshot()` and older iterable/data-based Uniqueue instances
+- `Leaderboard Protocol`: Adapted `LeaderboardCore` to documented `snapshot()` and `get()` APIs instead of private `.data` / `.indexes` internals
+- `Leaderboard Protocol`: Fixed persisted leaderboard loading after dependency upgrades
+- `Leaderboard Protocol`: Preserved top-N behavior by treating self-evicted low-priority records as no-op updates
+- `Relay Deployment`: GitHub Pages deploy now uses Node.js 22; `package.json` and lockfile declare `node >=22`; lockfile includes npm 10-compatible optional peer entries
+- `Relay Deployment`: Overrode `stylelint-order` to a Stylelint 17-compatible version and narrowed lint globs to source/html inputs so generated `dist/` assets are not linted
+- `Relay Deployment`: Inlined the needed shell helpers into both relay lifecycle scripts so one-file `curl` installs do not depend on local or remote helper scripts
+- `Relay Deployment`: Relay deployment now verifies both Node.js 22+ and npm, installing NodeSource Node.js when a distro provides node without npm
+- `Relay Deployment`: Fedora/RHEL/CentOS deployment now supports both `dnf` and `yum`, with optional EPEL, certbot-nginx, and SELinux utility fallbacks
+- `Relay Deployment`: Relay service now uses the resolved absolute npm binary instead of relying on `which npm` during unit generation
+- `Relay Deployment`: Temporary relay smoke test now uses `runuser` before falling back to `sudo`
+- `Relay Deployment`: Refactored removal into safer idempotent steps with explicit confirmation, safe app-directory deletion guard, nginx reload validation, and shared helpers
 
 ## 0.13.0 Svelte 5 + Dynamic Relays
 
-### P2P Infrastructure
-
-- `Dynamic Relay Configuration`: Users can add, remove, and reset relay servers via new Relays overlay (Options → Relays)
-- `Automatic Relay Migration`: New default relays auto-inject on app update; removed defaults auto-cleanup; custom user relays preserved
-- `libp2p Upgrade`: Migrated to libp2p v3 with floodsub (replacing gossipsub), updated stream handling from it-pipe to event-based API
-- `Relay Node`: Added `nodes/relay/` for self-hosted relay servers with `scripts/deploy-relay.sh` for one-command deployment
-- `Leaderboard Node`: Added `nodes/leaderboard/` headless peer with persistent storage (`data.json` tracked in git for bootstrap/backup)
-- `Environment Config`: `DIGIFALL_RELAYS` / `DIGIFALL_RELAY` env vars for custom relay configuration in server nodes
-
-### Svelte 5 Migration
-
-- `Runes API`: Full migration from Svelte 4 reactive statements (`$:`) to Svelte 5 runes (`$state`, `$derived`, `$effect`, `$props`, `$bindable`)
-- `Event Handlers`: Migrated from `on:event` directive syntax to `onevent` attribute syntax
-- `Snippets`: Replaced slots with `{@render children()}` snippet pattern in Dialog and VirtualScroll components
-
-### Validation & Security
-
-- `Moves Length Limit`: Added `MAX_MOVES_LENGTH` (40,000) early rejection before replay to prevent DoS via oversized records
-- `Multiaddr Validation`: Added `validateMultiaddr()` and `sanitizeMultiaddr()` for relay address validation
-
-### Architecture
-
-- `@digifall/leaderboard`: Shared npm workspace package for P2P leaderboard protocol
-  - `LeaderboardCore` class with queues, root hashes, and handler factories
-  - Protocol constants, utilities (`compare`, `parseMessage`, `toMessage`, `squashIntegers`, `getSeed`)
-  - `DEFAULT_RELAYS` as single source of truth
-- `Store Refactoring`: Renamed stores with `Store` suffix, added `.get()` synchronous accessor, created `createStore()` and `createDerivedStore()` factories
-- `Persistence Layer`: Refactored to `createLocalStorageStore()` and `createIndexedDBFactory()` with custom load/save support
-- `Derived Store Chains`: `relaysStore` → `activeRelaysStore` → `relayPeerIdsStore` for reactive relay management
-- `nodes/` restructured into separate folders: `nodes/relay/`, `nodes/leaderboard/`
-
-### Developer Experience
-
-- `AGENTS.md`: Added comprehensive project context documentation for AI-assisted development
-- `Type Annotations`: Added JSDoc typedefs for core entities (Card, GameRecord, ComboRow, LogEntry)
-- `New Scripts`: `npm run check` (svelte-check), `npm run format` (prettier), `npm run relay`, `npm run leaderboard`
+- `P2P Infrastructure`: Users can add, remove, and reset relay servers via new Relays overlay in Options
+- `P2P Infrastructure`: New default relays auto-inject on app update; removed defaults auto-cleanup; custom user relays preserved
+- `P2P Infrastructure`: Migrated to libp2p v3 with floodsub, replacing gossipsub, and updated stream handling from it-pipe to event-based API
+- `P2P Infrastructure`: Added `nodes/relay/` for self-hosted relay servers with `scripts/deploy-relay.sh` for one-command deployment
+- `P2P Infrastructure`: Added `nodes/leaderboard/` headless peer with persistent storage, with `data.json` tracked in git for bootstrap and backup
+- `P2P Infrastructure`: Added `DIGIFALL_RELAYS` and `DIGIFALL_RELAY` env vars for custom relay configuration in server nodes
+- `Svelte 5 Migration`: Full migration from Svelte 4 reactive statements to Svelte 5 runes
+- `Svelte 5 Migration`: Migrated from `on:event` directive syntax to `onevent` attribute syntax
+- `Svelte 5 Migration`: Replaced slots with `{@render children()}` snippet pattern in Dialog and VirtualScroll components
+- `Validation & Security`: Added `MAX_MOVES_LENGTH` early rejection before replay to prevent DoS via oversized records
+- `Validation & Security`: Added `validateMultiaddr()` and `sanitizeMultiaddr()` for relay address validation
+- `Architecture`: Added `@digifall/leaderboard` shared npm workspace package for P2P leaderboard protocol
+- `Architecture`: Renamed stores with `Store` suffix, added `.get()` synchronous accessor, created `createStore()` and `createDerivedStore()` factories
+- `Architecture`: Refactored persistence to `createLocalStorageStore()` and `createIndexedDBFactory()` with custom load/save support
+- `Architecture`: Added derived relay store chains from `relaysStore` to `activeRelaysStore` to `relayPeerIdsStore`
+- `Architecture`: Restructured `nodes/` into separate `nodes/relay/` and `nodes/leaderboard/` folders
+- `Developer Experience`: Added comprehensive project context documentation for AI-assisted development
+- `Developer Experience`: Added JSDoc typedefs for core entities such as Card, GameRecord, ComboRow, and LogEntry
+- `Developer Experience`: Added scripts for `npm run check`, `npm run format`, `npm run relay`, and `npm run leaderboard`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digifall",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digifall",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "workspaces": [
         "packages/*"
       ],
@@ -9366,6 +9366,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/svg-tags": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digifall",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "type": "module",
   "engines": {
     "node": ">=22"
@@ -20,7 +20,7 @@
     "relay": "node nodes/relay/index.js",
     "leaderboard": "node nodes/leaderboard/index.js",
     "validate-records": "node scripts/validate-records.js",
-    "test": "npm test --workspaces",
+    "test": "node --test src/*.test.js && npm test --workspaces",
     "check": "svelte-check --tsconfig ./jsconfig.json",
     "lint": "stylelint 'src/**/*.{css,svelte}' '*.html' 'public/**/*.html' --fix",
     "format": "prettier --write ."

--- a/packages/leaderboard/index.test.js
+++ b/packages/leaderboard/index.test.js
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LeaderboardCore,
+  computeRootHash,
+  compare,
+  parseMessage,
+  toMessage,
+} from "./index.js";
+
+test("compare sorts by value and then older timestamp", () => {
+  assert.equal(
+    compare({ value: 2, timestamp: 2 }, { value: 1, timestamp: 1 }),
+    1,
+  );
+  assert.equal(
+    compare({ value: 1, timestamp: 2 }, { value: 2, timestamp: 1 }),
+    -1,
+  );
+  assert.equal(
+    compare({ value: 1, timestamp: 1 }, { value: 1, timestamp: 2 }),
+    -1,
+  );
+});
+
+test("message helpers round-trip JSON payloads", () => {
+  const record = {
+    type: "highScore",
+    playerName: "llb",
+    timestamp: 1,
+    value: 10,
+  };
+  assert.deepEqual(parseMessage(toMessage(record)), record);
+});
+
+test("LeaderboardCore keeps only the best record per player", () => {
+  const core = new LeaderboardCore({
+    recordTypes: ["highScore"],
+    maxRecords: 10,
+  });
+  assert.equal(
+    core.handleRecord({
+      type: "highScore",
+      playerName: "llb",
+      timestamp: 1,
+      value: 10,
+    }),
+    true,
+  );
+  assert.equal(
+    core.handleRecord({
+      type: "highScore",
+      playerName: "llb",
+      timestamp: 2,
+      value: 5,
+    }),
+    false,
+  );
+  assert.deepEqual(
+    core.getData("highScore").map(({ value }) => value),
+    [10],
+  );
+});
+
+test("computeRootHash is order independent", () => {
+  const records = [
+    { playerName: "a", timestamp: 1, value: 10 },
+    { playerName: "b", timestamp: 2, value: 20 },
+  ];
+  assert.equal(computeRootHash(records), computeRootHash(records.toReversed()));
+});

--- a/packages/leaderboard/package.json
+++ b/packages/leaderboard/package.json
@@ -10,6 +10,9 @@
       "default": "./index.js"
     }
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "@llblab/uniqueue": "1.4.0",
     "uint8arrays": "5.1.1"

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -221,10 +221,18 @@
     event.preventDefault();
   }
 
+  function preventNativeTouchAction(event = {}) {
+    if (!event.type?.startsWith("touch") && event.type !== "contextmenu") {
+      return;
+    }
+    if (event.cancelable) event.preventDefault();
+  }
+
   export function longpress(node, { duration = 400 } = {}) {
     let timer;
     $effect(() => {
       const start = (event = {}) => {
+        preventNativeTouchAction(event);
         node.dispatchEvent(
           new CustomEvent("longpressstart", { bubbles: true, detail: event }),
         );
@@ -235,20 +243,29 @@
         }, duration);
       };
       const stop = (event = {}) => {
+        preventNativeTouchAction(event);
         clearTimeout(timer);
         node.dispatchEvent(
           new CustomEvent("longpressend", { bubbles: true, detail: event }),
         );
       };
-      node.addEventListener("mousedown", start, { passive: true });
-      node.addEventListener("touchstart", start, { passive: true });
-      node.addEventListener("touchend", stop, { passive: true });
-      window.addEventListener("mouseup", stop, { passive: true });
+      node.addEventListener("mousedown", start);
+      node.addEventListener("contextmenu", preventNativeTouchAction);
+      node.addEventListener("touchstart", start, { passive: false });
+      node.addEventListener("touchmove", preventNativeTouchAction, {
+        passive: false,
+      });
+      node.addEventListener("touchend", stop, { passive: false });
+      node.addEventListener("touchcancel", stop, { passive: false });
+      window.addEventListener("mouseup", stop);
       return () => {
         clearTimeout(timer);
         node.removeEventListener("mousedown", start);
+        node.removeEventListener("contextmenu", preventNativeTouchAction);
         node.removeEventListener("touchstart", start);
+        node.removeEventListener("touchmove", preventNativeTouchAction);
         node.removeEventListener("touchend", stop);
+        node.removeEventListener("touchcancel", stop);
         window.removeEventListener("mouseup", stop);
       };
     });
@@ -310,6 +327,9 @@
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" fill-opacity=".6"><rect x="4" width="4" height="4" /><rect y="4" width="4" height="4" /></svg>');
     background-size: 6rem;
     box-shadow: var(--gloss-inset), var(--shadow-inset);
+    touch-action: none;
+    -webkit-touch-callout: none;
+    user-select: none;
 
     &::before {
       position: absolute;

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -48,9 +48,12 @@
     width: 21rem;
     height: 21rem;
     cursor: pointer;
+    touch-action: none;
+    -webkit-touch-callout: none;
     transition-duration: calc(var(--card-duration) * 1ms);
     transition-property: bottom;
     transition-timing-function: cubic-bezier(0.56, 0, 1, 1);
+    user-select: none;
     will-change: bottom;
 
     &.blink {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,16 @@
 import { DEFAULT_RELAYS } from "@digifall/leaderboard";
 
-const localStorage = globalThis.localStorage;
+function getLocalStorageItem(key) {
+  try {
+    return globalThis.localStorage?.getItem(key);
+  } catch {
+    return null;
+  }
+}
 
-export const DEBUG = Boolean(localStorage?.getItem("debug"));
+export const DEBUG = Boolean(getLocalStorageItem("debug"));
 
-export const RELOAD_IN_SEC = Number(localStorage?.getItem("reload"));
+export const RELOAD_IN_SEC = Number(getLocalStorageItem("reload"));
 
 export const MAX_RECORDS = 1e3;
 

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -1,23 +1,46 @@
 import { get, writable } from "svelte/store";
 
+export function loadLocalStorageJson(key, initialValue) {
+  try {
+    const saved = globalThis.localStorage?.getItem(key);
+    return saved ? JSON.parse(saved) : initialValue;
+  } catch (error) {
+    console.warn(`Failed to load ${key} from localStorage`, error);
+    return initialValue;
+  }
+}
+
+function saveLocalStorageJson(key, value) {
+  try {
+    globalThis.localStorage?.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn(`Failed to save ${key} to localStorage`, error);
+  }
+}
+
 export function createLocalStorageStore(
   key,
   initialValue,
-  load = (initialValue) => {
-    const saved = localStorage.getItem(key);
-    return saved ? JSON.parse(saved) : initialValue;
-  },
-  save = (value) => {
-    localStorage.setItem(key, JSON.stringify(value));
-  },
+  load = (initialValue) => loadLocalStorageJson(key, initialValue),
+  save = (value) => saveLocalStorageJson(key, value),
 ) {
-  const store = writable(load(initialValue) || initialValue);
+  let value = initialValue;
+  try {
+    value = load(initialValue) || initialValue;
+  } catch (error) {
+    console.warn(`Failed to initialize ${key}`, error);
+  }
+  const store = writable(value);
   return {
     get() {
       return get(store);
     },
     set(value) {
-      save(value);
+      try {
+        save(value);
+      } catch (error) {
+        console.warn(`Failed to save ${key}`, error);
+      }
       store.set(value);
     },
     update(cb) {

--- a/src/persistence.test.js
+++ b/src/persistence.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createLocalStorageStore, loadLocalStorageJson } from "./persistence.js";
+
+function withLocalStorage(localStorage, callback) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorage,
+  });
+  try {
+    return callback();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "localStorage", descriptor);
+    } else {
+      delete globalThis.localStorage;
+    }
+  }
+}
+
+function withoutWarnings(callback) {
+  const warn = console.warn;
+  console.warn = () => {};
+  try {
+    return callback();
+  } finally {
+    console.warn = warn;
+  }
+}
+
+test("loadLocalStorageJson returns initial value when storage throws", () => {
+  const localStorage = {
+    getItem() {
+      throw new Error("blocked");
+    },
+  };
+  const result = withoutWarnings(() =>
+    withLocalStorage(localStorage, () =>
+      loadLocalStorageJson("options", { sound: true }),
+    ),
+  );
+  assert.deepEqual(result, { sound: true });
+});
+
+test("createLocalStorageStore updates in memory when storage save throws", () => {
+  const localStorage = {
+    getItem() {
+      return JSON.stringify({ value: 1 });
+    },
+    setItem() {
+      throw new Error("quota exceeded");
+    },
+  };
+  withoutWarnings(() =>
+    withLocalStorage(localStorage, () => {
+      const store = createLocalStorageStore("score", { value: 0 });
+      store.set({ value: 2 });
+      assert.deepEqual(store.get(), { value: 2 });
+    }),
+  );
+});
+
+test("createLocalStorageStore falls back on corrupt JSON", () => {
+  const localStorage = {
+    getItem() {
+      return "{";
+    },
+    setItem() {},
+  };
+  const result = withoutWarnings(() =>
+    withLocalStorage(localStorage, () => {
+      const store = createLocalStorageStore("relays", { active: [] });
+      return store.get();
+    }),
+  );
+  assert.deepEqual(result, { active: [] });
+});

--- a/src/stores.js
+++ b/src/stores.js
@@ -9,7 +9,10 @@ import {
   getComboFromLog,
   getSeed,
 } from "./core.js";
-import { createLocalStorageStore } from "./persistence.js";
+import {
+  createLocalStorageStore,
+  loadLocalStorageJson,
+} from "./persistence.js";
 import { playWordUp } from "./sounds.js";
 
 /** @typedef {import('./core.js').ComboRow} ComboRow */
@@ -105,8 +108,7 @@ export const relaysStore = createLocalStorageStore(
   KEYS.relays,
   INITIAL_VALUES.relays,
   function loadRelays(initialValue) {
-    const saved = localStorage.getItem(KEYS.relays);
-    const parsed = saved ? JSON.parse(saved) : null;
+    const parsed = loadLocalStorageJson(KEYS.relays, null);
     if (!parsed) return initialValue;
     const activeSet = new Set(parsed.active ?? []);
     const appliedSet = new Set(parsed.applied ?? []);


### PR DESCRIPTION
### Motivation

- Prevent Mobile Safari long taps from triggering native selection/callout or scrolling so long-press gameplay remains reliable on touch devices.
- Make client persistence resilient so unavailable, full, private-mode restricted, or corrupt `localStorage` does not block gameplay or state updates.
- Publish the fix as a patch release and refresh the root `package-lock.json` to align the lockfile metadata with the release.

### Description

- Added a `preventNativeTouchAction` guard and updated the `longpress` action in `src/Board.svelte` to call `preventDefault()` for cancellable touch/context events and switched relevant event listeners to non-passive listeners; also added `touch-action: none` and user-selection suppression in the board styles.
- Applied the same selection/callout suppression styles to `src/Card.svelte` so card surfaces also suppress native gestures.
- Introduced safe persistence helpers in `src/persistence.js`: `loadLocalStorageJson` and safe JSON saving around `localStorage` reads/writes, and updated `createLocalStorageStore` to initialize and persist without throwing when storage is unavailable or fails.
- Switched `src/constants.js` to use a safe `localStorage` accessor for `DEBUG` and `RELOAD_IN_SEC`, and updated `src/stores.js` to consume `loadLocalStorageJson` for relay loading logic.
- Added Node test coverage for localStorage fallback behavior and leaderboard protocol helpers so the workspace test command has a valid passing path.
- Flattened the changelog format to version sections with direct `domain`: description bullets.
- Updated documentation and metadata for the 0.14.3 hotfix release.

### Versioning

- Kept this as `0.14.3` because the release is a reliability hotfix, not a feature-bearing minor release.
- NPM publication was evaluated as a follow-up boundary: the root app is primarily a deployable PWA, while `@digifall/leaderboard` is the publishable workspace package and was not changed semantically in this hotfix.

### Testing

- `npm ci --ignore-scripts`
- `npm run check`
- `npm test`
- `npm run build`
- `npm run lint`
- `npm run validate-records -- nodes/leaderboard/data.json`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cbb23f3c08329bf16f663bcda02b5)
