### PR TITLE
0.15.1: leaderboard personal-best sync hotfix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,10 @@ Not a traditional game-as-product, but a protocol-as-game:
   - Rationale: Mobile Safari can throw on storage reads/writes; gameplay must continue because local persistence is not part of deterministic validation
   - Pattern: Catch storage failures at persistence boundaries, keep reactive store updates synchronous, and reuse safe JSON loaders for custom migrations
 
+- Personal-Best Leaderboard Sync: localStorage personal records must be replay-validated and queued into the IndexedDB leaderboard without phase gating
+  - Rationale: highCombo is saved during combo resolution; idle/gameOver-only sync can strand a valid local best until the user beats it again
+  - Pattern: Add record type on a copy, call `LeaderboardCore.handleRecordWithValidation()`, then persist updated leaderboard snapshots
+
 ### Shared Package Principles
 
 - Protocol vs Infrastructure Separation: Shared packages contain protocol logic (message formats, handlers); platform-specific code (libp2p config, storage backends) stays in consumers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## 0.15.1 Leaderboard Hotfix
+
+- `Leaderboard Reliability`: Local personal bests are now replay-validated and synced into the IndexedDB-backed leaderboard regardless of the current game phase, so high-combo records saved during combo resolution are not stranded in localStorage
+
 ## 0.15.0 Android Play Release Pipeline
 
 - `Android`: Added a Bubblewrap Trusted Web Activity configuration for package `com.llblab.digifall`, version-synced from `package.json`, so Digifall can ship to Google Play as a hosted PWA wrapper

--- a/android/twa-manifest.json
+++ b/android/twa-manifest.json
@@ -21,8 +21,8 @@
   "maskableIconUrl": "https://digifall.app/images/icon-512x512.png",
   "monochromeIconUrl": "https://digifall.app/images/icon-512x512.png",
   "splashScreenFadeOutDuration": 300,
-  "appVersion": "0.15.0",
-  "appVersionCode": 15000,
+  "appVersion": "0.15.1",
+  "appVersionCode": 15001,
   "signingKey": {
     "path": ".secrets/LLBLab.keystore",
     "alias": "LLBLab"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digifall",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digifall",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digifall",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/leaderboard.js
+++ b/src/leaderboard.js
@@ -17,12 +17,11 @@ import { multiaddr } from "@multiformats/multiaddr";
 import { IDBDatastore } from "datastore-idb";
 import { createLibp2p } from "libp2p";
 
-import { DEBUG, KEYS, MAX_RECORDS, PHASES, RECORD_TYPES } from "./constants.js";
+import { DEBUG, KEYS, MAX_RECORDS, RECORD_TYPES } from "./constants.js";
 import { createIndexedDBFactory } from "./persistence.js";
 import {
   activeRelaysStore,
   optionsStore,
-  phaseStore,
   recordsStore,
   relayPeerIdsStore,
 } from "./stores.js";
@@ -242,15 +241,17 @@ RECORD_TYPES.forEach((type) => {
 });
 
 recordsStore.subscribe((records) => {
-  const phase = phaseStore.get();
-  if (phase !== PHASES.idle && phase !== PHASES.gameOver) return;
-  RECORD_TYPES.forEach((type) => {
-    const record = records[type];
-    if (record[KEYS.value] === 0) return;
-    record[KEYS.type] = type;
-    core.handleRecord(record);
-    leaderboardStores[type].set(core.getData(type));
-  });
+  Promise.allSettled(
+    RECORD_TYPES.map(async (type) => {
+      const record = records[type];
+      if (record[KEYS.value] === 0) return;
+      const updated = await core.handleRecordWithValidation({
+        ...record,
+        [KEYS.type]: type,
+      });
+      if (updated) leaderboardStores[type].set(core.getData(type));
+    }),
+  );
 });
 
 let relaysInitialized = false;


### PR DESCRIPTION
## Summary

This hotfix restores leaderboard synchronization for local personal-best records, especially high-combo records saved during combo resolution.

It also routes local personal-best promotion through replay validation before writing updated leaderboard snapshots, preserving the trust boundary between localStorage personal records and IndexedDB leaderboard data.

## Why

A local high-combo record could be saved in localStorage during the `combo` phase but never copied into the IndexedDB-backed leaderboard because synchronization was gated to `idle` and `gameOver`. If the player did not beat that local record again, the leaderboard could remain stuck on an older value.

## User-visible behavior

- Valid existing local personal bests can sync into the leaderboard on the next app load.
- New high-combo personal bests are no longer stranded by phase timing.
- Invalid local records are rejected by replay validation before leaderboard persistence.

## Changed areas

- `src/leaderboard.js`: removes phase-gated local-record sync and validates local personal-best promotion through `LeaderboardCore.handleRecordWithValidation()`.
- Release metadata: bumps Digifall to `0.15.1` and Android TWA versionCode to `15001`.
- Context/history: records the leaderboard sync rule and release notes.

## Risk Notes

- Startup may replay-validate existing non-zero local personal bests; the queue short-circuits when equal or better leaderboard records already exist.
- No storage schema, relay, or gameplay state-machine migration required.

## Validation

- `npm test` — passed
- `npm run check` — passed
- `npm run lint` — passed
- `npm run build` — passed
- `node android/compute-version-code.mjs 0.15.1` — passed (`15001`)
- `node android/sync-twa-version.mjs` — passed
- `npm run validate-records -- nodes/leaderboard/data.json` — passed
- `repo_context_check` — passed with existing AGENTS.md density warnings only