### PR TITLE
0.15.4: mobile fall animation smoothness, engine and dependency refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.15.4 Mobile Fall Animation Smoothness
+
+- `Rendering`: Card fall animations now use GPU-composited transforms instead of layout offsets, removing per-frame reflow on mobile — falling cards stay smooth during match resolution on low-end devices
+- `Rendering`: Leaderboard type switching (combos/scores) animates with transforms instead of layout offsets
+- `Engine`: Match collapse in the deterministic core dropped from quadratic filter-and-sort to a single pass, speeding up match resolution and record replay validation
+- `Dependencies`: Refreshed the libp2p stack, Svelte, Vite, PostCSS, and related lockfile dependencies; fixed the high-severity `brace-expansion` advisory (0 known vulnerabilities)
 ## 0.15.3 Android 16 Compatibility Hotfix
 
 - `Android Compatibility`: Android release builds now compile against and target Android 16 (API level 36) while preserving Bubblewrap's minimum-device compatibility, satisfying the Google Play target API requirement

--- a/android/twa-manifest.json
+++ b/android/twa-manifest.json
@@ -21,8 +21,8 @@
   "maskableIconUrl": "https://digifall.app/images/icon-512x512.png",
   "monochromeIconUrl": "https://digifall.app/images/icon-512x512.png",
   "splashScreenFadeOutDuration": 300,
-  "appVersion": "0.15.3",
-  "appVersionCode": 15003,
+  "appVersion": "0.15.4",
+  "appVersionCode": 15004,
   "signingKey": {
     "path": ".secrets/LLBLab.keystore",
     "alias": "LLBLab"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,27 +13,27 @@
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "14.1.2",
         "@chainsafe/libp2p-yamux": "8.0.1",
-        "@libp2p/bootstrap": "12.0.27",
-        "@libp2p/circuit-relay-v2": "4.2.9",
-        "@libp2p/config": "1.1.34",
-        "@libp2p/floodsub": "11.0.26",
-        "@libp2p/identify": "4.1.10",
+        "@libp2p/bootstrap": "12.0.29",
+        "@libp2p/circuit-relay-v2": "4.2.11",
+        "@libp2p/config": "1.1.36",
+        "@libp2p/floodsub": "11.0.28",
+        "@libp2p/identify": "4.1.12",
         "@libp2p/interface": "3.2.5",
-        "@libp2p/keychain": "6.1.4",
-        "@libp2p/plaintext": "3.0.24",
+        "@libp2p/keychain": "6.1.6",
+        "@libp2p/plaintext": "3.0.26",
         "@libp2p/pubsub-peer-discovery": "12.0.0",
-        "@libp2p/websockets": "10.1.17",
+        "@libp2p/websockets": "10.1.19",
         "@multiformats/multiaddr": "13.0.3",
         "datastore-fs": "12.0.1",
         "datastore-idb": "5.0.1",
         "howler": "2.2.4",
-        "libp2p": "3.3.6",
+        "libp2p": "3.3.8",
         "uint8arrays": "6.1.1"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "7.2.0",
         "autoprefixer": "10.5.4",
-        "postcss": "8.5.22",
+        "postcss": "8.5.25",
         "postcss-nested": "7.0.2",
         "prettier": "3.9.6",
         "prettier-plugin-svelte": "4.1.1",
@@ -43,9 +43,9 @@
         "stylelint-config-idiomatic-order": "10.0.0",
         "stylelint-config-standard": "40.0.0",
         "stylelint-order": "8.1.1",
-        "svelte": "5.56.7",
-        "svelte-check": "4.7.3",
-        "vite": "8.1.5",
+        "svelte": "5.56.8",
+        "svelte-check": "4.7.4",
+        "vite": "8.2.0",
         "vite-plugin-pwa": "1.3.0",
         "workbox-build": "7.4.1"
       },
@@ -1914,40 +1914,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -2050,68 +2016,68 @@
       "license": "MIT"
     },
     "node_modules/@libp2p/bootstrap": {
-      "version": "12.0.27",
-      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-12.0.27.tgz",
-      "integrity": "sha512-p6sIulcqA0esESAnwaMHfW2Nvs9pRj0OUWHriwDy3lssLNytpCnCppzG5wCqNxRPufrS10sxbwFyoFd6HRw9+Q==",
+      "version": "12.0.29",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-12.0.29.tgz",
+      "integrity": "sha512-HJqRyr75io10F/zaJCMGhrdOi7an4bJmgw12DLrBR/hPteeFAIZ4bXeiV+GNxw5vmRJoEpfUTVzIwPTsRJMViw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/interface-internal": "^3.1.9",
-        "@libp2p/peer-id": "^6.0.12",
+        "@libp2p/interface-internal": "^3.1.11",
+        "@libp2p/peer-id": "^6.0.14",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "main-event": "^1.0.1"
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/@libp2p/interface-internal": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.9.tgz",
-      "integrity": "sha512-YLe27t4t/EWGkLX/S+sOPOc++iga44LGW2WJgxXaGGgMVc9G7C1/mUq+So1AyWxl+NqdvN9jbx03hqhrAo1ltA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.11.tgz",
+      "integrity": "sha512-lHJueWKdfkf/nrbVkGNUWrqDvF3T9Brn4hyONQmhTqG2mWyWKntRR/CkPjVgMRDSF2fuyzDJGg+n9tC0Gphk8g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-collections": "^7.0.24",
+        "@libp2p/peer-collections": "^7.0.26",
         "@multiformats/multiaddr": "^13.0.3",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/bootstrap/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/circuit-relay-v2": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-4.2.9.tgz",
-      "integrity": "sha512-v6DeDg+KV/4dzr0XXGJK9ILaOxdz1uImmxpLpavRjKC/br2hCtUpQYsoF0h0YnFejj6j6lvYPn5+sZF2q6FHtg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-4.2.11.tgz",
+      "integrity": "sha512-q47qWuJxmNocAX4oRAUWpp2d56aiymsih9ORCkBdQGUkBzynPyBsucvCX5bnF8tb80Ji5wBHl4jCa1DmrW1T1A==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/interface-internal": "^3.1.9",
-        "@libp2p/peer-collections": "^7.0.24",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/peer-record": "^9.0.13",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/interface-internal": "^3.1.11",
+        "@libp2p/peer-collections": "^7.0.26",
+        "@libp2p/peer-id": "^6.0.14",
+        "@libp2p/peer-record": "^9.0.15",
+        "@libp2p/utils": "^7.3.2",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "any-signal": "^4.1.1",
         "main-event": "^1.0.1",
         "multiformats": "^14.0.0",
-        "nanoid": "^5.1.5",
+        "nanoid": "^6.0.0",
         "progress-events": "^1.1.0",
         "protons-runtime": "^7.0.0",
         "retimeable-signal": "^1.0.1",
@@ -2120,33 +2086,33 @@
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@libp2p/interface-internal": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.9.tgz",
-      "integrity": "sha512-YLe27t4t/EWGkLX/S+sOPOc++iga44LGW2WJgxXaGGgMVc9G7C1/mUq+So1AyWxl+NqdvN9jbx03hqhrAo1ltA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.11.tgz",
+      "integrity": "sha512-lHJueWKdfkf/nrbVkGNUWrqDvF3T9Brn4hyONQmhTqG2mWyWKntRR/CkPjVgMRDSF2fuyzDJGg+n9tC0Gphk8g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-collections": "^7.0.24",
+        "@libp2p/peer-collections": "^7.0.26",
         "@multiformats/multiaddr": "^13.0.3",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/circuit-relay-v2/node_modules/protons-runtime": {
@@ -2180,22 +2146,22 @@
       }
     },
     "node_modules/@libp2p/config": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/@libp2p/config/-/config-1.1.34.tgz",
-      "integrity": "sha512-av0PNvJBTTwHxC1wFsjyvPuwHsE7mZOm0sQ7n0wKC5ONW/HfgGrpSiffjuPnDixJd3A/MkVNq5ycaQeM44Nb6Q==",
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/@libp2p/config/-/config-1.1.36.tgz",
+      "integrity": "sha512-DWP4CRU/Datb8t8mvGF1LQtc45Z3kZBEzG1Ua+1CuLcm+unLkRr2UcNyb4AG8nSA9jdQQocO2sQHofQ/9LTmBg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/keychain": "^6.1.4",
-        "@libp2p/logger": "^6.2.10",
+        "@libp2p/keychain": "^6.1.6",
+        "@libp2p/logger": "^6.2.12",
         "interface-datastore": "^10.0.1"
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.21.tgz",
-      "integrity": "sha512-GipsBinthJuk7DpwthTUixZHSaKogcxm2glPCP0VkYkEpzZrfEvBEekRvlP5+1Ak8pReaHcz4gPKFA9X6MG0WQ==",
+      "version": "5.1.22",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.22.tgz",
+      "integrity": "sha512-yVk4BefSiEz044kjsiLSEoJTbhRoyamqx4kFI9LnX8/asr4wnqDWKTXcn6mSx/RVNEzmDO70l3vOvcMCl4aLCQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
@@ -2244,17 +2210,17 @@
       }
     },
     "node_modules/@libp2p/floodsub": {
-      "version": "11.0.26",
-      "resolved": "https://registry.npmjs.org/@libp2p/floodsub/-/floodsub-11.0.26.tgz",
-      "integrity": "sha512-Tqgtkng+AqtYeG1VAn+bEdHDSQrWBnJwH6HawMbIGdkcWtKWO2N2kUpPS+hWmVCjQAXccyB4SbMwbteH/Jgk0Q==",
+      "version": "11.0.28",
+      "resolved": "https://registry.npmjs.org/@libp2p/floodsub/-/floodsub-11.0.28.tgz",
+      "integrity": "sha512-EgSuwmLzLsCkgZTrcX3VUhPeapfG2RVXi1AIoicp9CWO8PH3dZpPReOwC1K47UIoblhgt0l1LR5Q4nLiOidW9Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/interface-internal": "^3.1.9",
-        "@libp2p/peer-collections": "^7.0.24",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/interface-internal": "^3.1.11",
+        "@libp2p/peer-collections": "^7.0.26",
+        "@libp2p/peer-id": "^6.0.14",
+        "@libp2p/utils": "^7.3.2",
         "it-length-prefixed": "^11.0.1",
         "main-event": "^1.0.1",
         "multiformats": "^14.0.0",
@@ -2265,24 +2231,24 @@
       }
     },
     "node_modules/@libp2p/floodsub/node_modules/@libp2p/interface-internal": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.9.tgz",
-      "integrity": "sha512-YLe27t4t/EWGkLX/S+sOPOc++iga44LGW2WJgxXaGGgMVc9G7C1/mUq+So1AyWxl+NqdvN9jbx03hqhrAo1ltA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.11.tgz",
+      "integrity": "sha512-lHJueWKdfkf/nrbVkGNUWrqDvF3T9Brn4hyONQmhTqG2mWyWKntRR/CkPjVgMRDSF2fuyzDJGg+n9tC0Gphk8g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-collections": "^7.0.24",
+        "@libp2p/peer-collections": "^7.0.26",
         "@multiformats/multiaddr": "^13.0.3",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/floodsub/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
@@ -2312,9 +2278,9 @@
       }
     },
     "node_modules/@libp2p/floodsub/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/floodsub/node_modules/protons-runtime": {
@@ -2348,17 +2314,17 @@
       }
     },
     "node_modules/@libp2p/identify": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-4.1.10.tgz",
-      "integrity": "sha512-sD4n8avW/hZ5Du3ZuaNybS8jhBXzsMTeGO9dcwaF0BcHtDFIoYZ1kiMR8pxTePV4hB833TpBwlxhaxmIV1jX8g==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-4.1.12.tgz",
+      "integrity": "sha512-nNBnxSclPVsvRsaLlwX9cz7gO020KjWEsaSzqDryWz6VStbLLdcwJYkVUP3do7VoFHkkF8PMQkScW7XCA27ZOA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/interface-internal": "^3.1.9",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/peer-record": "^9.0.13",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/interface-internal": "^3.1.11",
+        "@libp2p/peer-id": "^6.0.14",
+        "@libp2p/peer-record": "^9.0.15",
+        "@libp2p/utils": "^7.3.2",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "it-drain": "^3.0.10",
@@ -2370,33 +2336,33 @@
       }
     },
     "node_modules/@libp2p/identify/node_modules/@libp2p/interface-internal": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.9.tgz",
-      "integrity": "sha512-YLe27t4t/EWGkLX/S+sOPOc++iga44LGW2WJgxXaGGgMVc9G7C1/mUq+So1AyWxl+NqdvN9jbx03hqhrAo1ltA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.11.tgz",
+      "integrity": "sha512-lHJueWKdfkf/nrbVkGNUWrqDvF3T9Brn4hyONQmhTqG2mWyWKntRR/CkPjVgMRDSF2fuyzDJGg+n9tC0Gphk8g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-collections": "^7.0.24",
+        "@libp2p/peer-collections": "^7.0.26",
         "@multiformats/multiaddr": "^13.0.3",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/identify/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/identify/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/identify/node_modules/protons-runtime": {
@@ -2601,12 +2567,12 @@
       }
     },
     "node_modules/@libp2p/keychain": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-6.1.4.tgz",
-      "integrity": "sha512-vExk59BOOoOafgPpnARFxacFvtiotOzJ/UZKdmZLGP9e0J1rJPm+Aqbek7aP4oA7JX0q2OjLK/skJSzbwUk9sQ==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-6.1.6.tgz",
+      "integrity": "sha512-G4xT3A8M5yiOJAcYT4YTnq9Gd3HOzHOIig1/KzcXzxaeuYCwXOmzreqUYabuEMmExkn966g5jiJ7RkCDQWO3UA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "@noble/hashes": "^2.0.1",
         "asn1js": "^3.0.6",
@@ -2617,15 +2583,15 @@
       }
     },
     "node_modules/@libp2p/keychain/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/logger": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.10.tgz",
-      "integrity": "sha512-recRqNABHG32YXvpMvNepFCuU14d51dF5hs+vR2C/tkqXBQc0Sqg5LtWB2NYPoIJV+JUB50iWLrvBXZUOjLc9Q==",
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-6.2.12.tgz",
+      "integrity": "sha512-FwCdJ5hGFDvWI/SULZ4Iez+k+JtdMAj4/EK6bWmkh08ORIztwKpt0IXCOe8nIfKhBKwLYJu00BnZDRsedX7+7Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
@@ -2642,13 +2608,13 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-7.0.24.tgz",
-      "integrity": "sha512-upJO+r79XYI0IxEVpTpCW3gK1fxLIoZEywO2N0kn2zwcYSNMqCNe9Ahm1YfRJLTFhusVRue9k4SAMyHvWiAXOA==",
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-7.0.26.tgz",
+      "integrity": "sha512-bbKMgu7W/J6eknQODGpySshZq9QWEYbIM/fMYrihbdIT/eS1h+8U6ko2qylfwbDyYlnUoYP45Cqi+oxoNwGH3Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/utils": "^7.3.2",
         "it-length-prefixed": "^11.0.1",
         "uint8arraylist": "^3.0.2",
         "uint8arrays": "^6.1.1"
@@ -2697,33 +2663,33 @@
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-7.0.24.tgz",
-      "integrity": "sha512-RBwYVj0gtO1VMjxjjlAzHqztB9fJyL/U3G5vJrpHdXWtGlXs5ZzpkW65nGXkBExKpoGRAV59WIkOOeRDiX9c2Q==",
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-7.0.26.tgz",
+      "integrity": "sha512-hjJbC/Jo1TjxqaKph2W6ARRnrNoBCEbSQMUsGT17JXQktJc7ImVGLoFy2VsZoJGMX4RLN+gKp6f8McFGb5Vi1w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/peer-id": "^6.0.14",
+        "@libp2p/utils": "^7.3.2",
         "multiformats": "^14.0.0"
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/peer-collections/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-id": {
@@ -2779,14 +2745,14 @@
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-9.0.13.tgz",
-      "integrity": "sha512-lkdZUNC6h86YECpRE3dB4GLYSiLLuXFBleiM01oEmWtAdTCfRd+vRqNkguSoC6R3tGk/YWRm7cfz39ATPuq7zQ==",
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-9.0.15.tgz",
+      "integrity": "sha512-WZH9Xkdvpr6TlM6eDdE/KZJmk558jrAC/ufNHnbWXdEUxF/GTzx7RsrBgaC6cPGBTNTjzICfO6vZKR2US0Fl9Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-id": "^6.0.12",
+        "@libp2p/peer-id": "^6.0.14",
         "@multiformats/multiaddr": "^13.0.3",
         "multiformats": "^14.0.0",
         "protons-runtime": "^7.0.0",
@@ -2796,21 +2762,21 @@
       }
     },
     "node_modules/@libp2p/peer-record/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/peer-record/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-record/node_modules/protons-runtime": {
@@ -2844,16 +2810,16 @@
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "12.0.24",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-12.0.24.tgz",
-      "integrity": "sha512-OjyHJoHioCUK3hwfH5Ew5YRzViE0mA8lH/Wl0giQpNmV9H0FVLdlgoq2qDjOk4f6iG/Zpk99MOa4GGra5tAbKg==",
+      "version": "12.0.26",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-12.0.26.tgz",
+      "integrity": "sha512-VoLjd7SQrYN45w3pnGl8YQQn+9tzMsoZxdmSG7VWoMiQhMLyxCtkctsVi9OCdT1IkdelPRq84KHklkK0D4FG9w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-collections": "^7.0.24",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/peer-record": "^9.0.13",
+        "@libp2p/peer-collections": "^7.0.26",
+        "@libp2p/peer-id": "^6.0.14",
+        "@libp2p/peer-record": "^9.0.15",
         "@multiformats/multiaddr": "^13.0.3",
         "interface-datastore": "^10.0.1",
         "it-all": "^3.0.9",
@@ -2866,21 +2832,21 @@
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/peer-store/node_modules/protons-runtime": {
@@ -2914,36 +2880,36 @@
       }
     },
     "node_modules/@libp2p/plaintext": {
-      "version": "3.0.24",
-      "resolved": "https://registry.npmjs.org/@libp2p/plaintext/-/plaintext-3.0.24.tgz",
-      "integrity": "sha512-ywJV8S0DcdQIa6e1Vgxd2yEf1fUY1MrhS7o2Z0UrsWRju8Hi833B1OxgZheTcYBVHySQdtWHpP13HJZedoaV8w==",
+      "version": "3.0.26",
+      "resolved": "https://registry.npmjs.org/@libp2p/plaintext/-/plaintext-3.0.26.tgz",
+      "integrity": "sha512-10wbbR3PulwMzmAyev9PdL16YhanYnlsAkFRZ6G+y3gA9RXs63M5v1DEW6RjproK1iLrVmG5MqfM22uLYnvwfg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/peer-id": "^6.0.14",
+        "@libp2p/utils": "^7.3.2",
         "protons-runtime": "^7.0.0",
         "uint8arraylist": "^3.0.2",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/plaintext/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/@libp2p/plaintext/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/@libp2p/plaintext/node_modules/protons-runtime": {
@@ -3234,20 +3200,20 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.3.0.tgz",
-      "integrity": "sha512-7mDQQVutmz6LsrehO9W12RI0Hwnx/zQzqlsj1DB0/2vHf8As/4jEntoEM8ko6RAOaDQ7Y5OrJ2Fgd7O9gyVRkA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-nVfJkTE3QMa/LVKVD5sKDB8birKua0BR0oKoqnLSXsX1ez89PvhR1zZjBfARSGVZdv5qUmblcdcvjJ76HD0CWA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/logger": "^6.2.10",
+        "@libp2p/logger": "^6.2.12",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "@sindresorhus/fnv1a": "^3.1.0",
         "any-signal": "^4.1.1",
-        "cborg": "^5.1.0",
+        "cborg": "^6.0.0",
         "delay": "^7.0.0",
         "is-loopback-addr": "^2.0.2",
         "it-length-prefixed": "^11.0.1",
@@ -3320,13 +3286,13 @@
       }
     },
     "node_modules/@libp2p/websockets": {
-      "version": "10.1.17",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-10.1.17.tgz",
-      "integrity": "sha512-vFhuadZIMUiVm7bKROxrmwi8fQqHO1kTKzxbztLFHI6Hxx8Z0y5VPQmxqsqQLm85YxehxPTbhOmi0cNzop00/w==",
+      "version": "10.1.19",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-10.1.19.tgz",
+      "integrity": "sha512-inY5dWhm+mCrnS/wcHIWtDZ908c1W7UkpXE9i6uvnJVapWbvonvX9GEsTLvh4NbL7SOfnOHGkwDVgx1M2RxcRA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/utils": "^7.3.2",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
         "@multiformats/multiaddr-to-uri": "^12.0.0",
@@ -3431,25 +3397,6 @@
         "uint8arrays": "^6.0.0"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@noble/curves": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
@@ -3513,9 +3460,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3523,9 +3470,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+      "integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
       "cpu": [
         "arm64"
       ],
@@ -3540,9 +3487,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+      "integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
       "cpu": [
         "arm64"
       ],
@@ -3557,9 +3504,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+      "integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
       "cpu": [
         "x64"
       ],
@@ -3574,9 +3521,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+      "integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
       "cpu": [
         "x64"
       ],
@@ -3591,9 +3538,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+      "integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
       "cpu": [
         "arm"
       ],
@@ -3608,9 +3555,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+      "integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
       "cpu": [
         "arm64"
       ],
@@ -3625,9 +3572,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+      "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
       "cpu": [
         "arm64"
       ],
@@ -3642,9 +3589,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+      "integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
       "cpu": [
         "ppc64"
       ],
@@ -3659,9 +3606,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+      "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
       "cpu": [
         "s390x"
       ],
@@ -3676,9 +3623,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+      "integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
       "cpu": [
         "x64"
       ],
@@ -3693,9 +3640,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+      "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
       "cpu": [
         "x64"
       ],
@@ -3710,9 +3657,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+      "integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
       "cpu": [
         "arm64"
       ],
@@ -3726,29 +3673,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+      "integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
       "cpu": [
         "arm64"
       ],
@@ -3763,9 +3691,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+      "integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
       "cpu": [
         "x64"
       ],
@@ -4305,9 +4233,9 @@
       }
     },
     "node_modules/@sveltejs/load-config": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
-      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.1.tgz",
+      "integrity": "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4348,17 +4276,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/estree": {
@@ -4693,16 +4610,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4854,9 +4771,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cborg": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.1.tgz",
-      "integrity": "sha512-BDbSRIp6XrQXkTc7g+DN0RB9RrDPTUfals2ecWUlt3juPLjbAvy/V72mJcXY0Ehu0Dq/3WpNCOCT68HUTbW+lw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-6.1.1.tgz",
+      "integrity": "sha512-Ci8+V1OMFtqea8EXicsATqV+3kEqCGXCicM+5MEzpKTxqy58WMzhJUjtUqAjfWpKPZ0wpG8F+u5mC8Xy/0Zevg==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -5713,9 +5630,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7254,22 +7171,22 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-3.3.6.tgz",
-      "integrity": "sha512-iMC6d7Mg+q0x9gwUmw6BGBc/QccOBkx1T6l0xZF4CmVonBe5ndPD5Xryn+EbThxx+37enfTmEZ3XMZAiVbcg4g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-3.3.8.tgz",
+      "integrity": "sha512-CMDYzEflxjtDkRV4vx8u4H93VxnPJOnntqd1pumrb5meorpe3hppxvwvgUc/eQ/5+ZwRQCgFi1rUfaaQt0zy0g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.1.0",
         "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/interface-internal": "^3.1.9",
-        "@libp2p/logger": "^6.2.10",
-        "@libp2p/multistream-select": "^7.0.24",
-        "@libp2p/peer-collections": "^7.0.24",
-        "@libp2p/peer-id": "^6.0.12",
-        "@libp2p/peer-store": "^12.0.24",
-        "@libp2p/utils": "^7.3.0",
+        "@libp2p/interface-internal": "^3.1.11",
+        "@libp2p/logger": "^6.2.12",
+        "@libp2p/multistream-select": "^7.0.26",
+        "@libp2p/peer-collections": "^7.0.26",
+        "@libp2p/peer-id": "^6.0.14",
+        "@libp2p/peer-store": "^12.0.26",
+        "@libp2p/utils": "^7.3.2",
         "@multiformats/dns": "^1.0.6",
         "@multiformats/multiaddr": "^13.0.3",
         "@multiformats/multiaddr-matcher": "^3.0.2",
@@ -7289,39 +7206,39 @@
       }
     },
     "node_modules/libp2p/node_modules/@libp2p/interface-internal": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.9.tgz",
-      "integrity": "sha512-YLe27t4t/EWGkLX/S+sOPOc++iga44LGW2WJgxXaGGgMVc9G7C1/mUq+So1AyWxl+NqdvN9jbx03hqhrAo1ltA==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-3.1.11.tgz",
+      "integrity": "sha512-lHJueWKdfkf/nrbVkGNUWrqDvF3T9Brn4hyONQmhTqG2mWyWKntRR/CkPjVgMRDSF2fuyzDJGg+n9tC0Gphk8g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@libp2p/interface": "^3.2.5",
-        "@libp2p/peer-collections": "^7.0.24",
+        "@libp2p/peer-collections": "^7.0.26",
         "@multiformats/multiaddr": "^13.0.3",
         "progress-events": "^1.0.1"
       }
     },
     "node_modules/libp2p/node_modules/@libp2p/peer-id": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.12.tgz",
-      "integrity": "sha512-U44MeKs+U1SqZPqS0RDzjjcS9ERix2zJsJkTcqi8I+5flEz4uVAObBDxvkkaTaqRFRXCXEPjL5kA4UbgVubCZQ==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-6.0.14.tgz",
+      "integrity": "sha512-tquBouwbUXgntPtT5q4vfaXbNWmSzh2zo4p2u8IzclVvggXOpmyBlAUNPXDiFqZvQpsxVBrTTemmn0+AwDwecg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^5.1.21",
+        "@libp2p/crypto": "^5.1.22",
         "@libp2p/interface": "^3.2.5",
         "multiformats": "^14.0.0",
         "uint8arrays": "^6.1.1"
       }
     },
     "node_modules/libp2p/node_modules/multiformats": {
-      "version": "14.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
-      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.5.tgz",
+      "integrity": "sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -7335,23 +7252,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -7370,9 +7287,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -7391,9 +7308,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -7412,9 +7329,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -7433,9 +7350,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -7454,9 +7371,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -7475,9 +7392,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -7496,9 +7413,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -7517,9 +7434,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -7538,9 +7455,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -7559,9 +7476,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -7757,9 +7674,9 @@
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
-      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+      "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
       "funding": [
         {
           "type": "github",
@@ -7771,7 +7688,7 @@
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^22 || ^24 || >=26"
       }
     },
     "node_modules/netmask": {
@@ -8059,9 +7976,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -8543,13 +8460,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
+      "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -8559,21 +8476,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm64": "1.2.2",
+        "@rolldown/binding-darwin-arm64": "1.2.2",
+        "@rolldown/binding-darwin-x64": "1.2.2",
+        "@rolldown/binding-freebsd-x64": "1.2.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.2",
+        "@rolldown/binding-linux-arm64-musl": "1.2.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-gnu": "1.2.2",
+        "@rolldown/binding-linux-x64-musl": "1.2.2",
+        "@rolldown/binding-openharmony-arm64": "1.2.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.2",
+        "@rolldown/binding-win32-x64-msvc": "1.2.2"
       }
     },
     "node_modules/rollup": {
@@ -9424,9 +9340,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.56.7",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.7.tgz",
-      "integrity": "sha512-5qERUZX80oQj6XrDMUmD2Uhd/cIpCPDWWKBK3ZHmyRUC9apPyamWM8xMo31mbWsIQxwG2hVoSnOJ/EcnhVkkzQ==",
+      "version": "5.56.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+      "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9452,14 +9368,14 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.3.tgz",
-      "integrity": "sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.4.tgz",
+      "integrity": "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@sveltejs/load-config": "^0.2.0",
+        "@sveltejs/load-config": "^0.2.1",
         "chokidar": "^4.0.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
@@ -9473,7 +9389,7 @@
       },
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": ">=5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/svelte-check/node_modules/fdir": {
@@ -10009,16 +9925,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.17",
-        "rolldown": "~1.1.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -10035,7 +9951,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digifall",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "type": "module",
   "engines": {
     "node": ">=22"
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "7.2.0",
     "autoprefixer": "10.5.4",
-    "postcss": "8.5.22",
+    "postcss": "8.5.25",
     "postcss-nested": "7.0.2",
     "prettier": "3.9.6",
     "prettier-plugin-svelte": "4.1.1",
@@ -38,30 +38,30 @@
     "stylelint-config-idiomatic-order": "10.0.0",
     "stylelint-config-standard": "40.0.0",
     "stylelint-order": "8.1.1",
-    "svelte": "5.56.7",
-    "svelte-check": "4.7.3",
-    "vite": "8.1.5",
+    "svelte": "5.56.8",
+    "svelte-check": "4.7.4",
+    "vite": "8.2.0",
     "vite-plugin-pwa": "1.3.0",
     "workbox-build": "7.4.1"
   },
   "dependencies": {
     "@chainsafe/libp2p-gossipsub": "14.1.2",
     "@chainsafe/libp2p-yamux": "8.0.1",
-    "@libp2p/bootstrap": "12.0.27",
-    "@libp2p/circuit-relay-v2": "4.2.9",
-    "@libp2p/config": "1.1.34",
-    "@libp2p/floodsub": "11.0.26",
-    "@libp2p/identify": "4.1.10",
+    "@libp2p/bootstrap": "12.0.29",
+    "@libp2p/circuit-relay-v2": "4.2.11",
+    "@libp2p/config": "1.1.36",
+    "@libp2p/floodsub": "11.0.28",
+    "@libp2p/identify": "4.1.12",
     "@libp2p/interface": "3.2.5",
-    "@libp2p/keychain": "6.1.4",
-    "@libp2p/plaintext": "3.0.24",
+    "@libp2p/keychain": "6.1.6",
+    "@libp2p/plaintext": "3.0.26",
     "@libp2p/pubsub-peer-discovery": "12.0.0",
-    "@libp2p/websockets": "10.1.17",
+    "@libp2p/websockets": "10.1.19",
     "@multiformats/multiaddr": "13.0.3",
     "datastore-fs": "12.0.1",
     "datastore-idb": "5.0.1",
     "howler": "2.2.4",
-    "libp2p": "3.3.6",
+    "libp2p": "3.3.8",
     "uint8arrays": "6.1.1"
   }
 }

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -43,18 +43,19 @@
   :global .card {
     position: absolute;
     z-index: var(--card-y);
-    bottom: calc(var(--card-y) * 21rem);
+    bottom: 0;
     left: calc(var(--card-x) * 21rem);
     width: 21rem;
     height: 21rem;
     cursor: pointer;
     touch-action: none;
     -webkit-touch-callout: none;
+    transform: translate3d(0, calc(-1 * var(--card-y) * 21rem), 0);
     transition-duration: calc(var(--card-duration) * 1ms);
-    transition-property: bottom;
+    transition-property: transform;
     transition-timing-function: cubic-bezier(0.56, 0, 1, 1);
     user-select: none;
-    will-change: bottom;
+    will-change: transform;
 
     &.blink {
       animation: fade-out 400ms ease 400ms forwards;
@@ -114,7 +115,11 @@
         box-shadow: none;
         filter: drop-shadow(0 0 1px white) drop-shadow(0 0 1px white)
           drop-shadow(0 0 1px white) drop-shadow(0 0 1px white);
-        transform: translateX(-0.5px) translateY(-0.5px);
+        transform: translate3d(
+          -0.5px,
+          calc(-1 * var(--card-y) * 21rem - 0.5px),
+          0
+        );
 
         .current {
           border-right: 0.5px solid var(--color);
@@ -127,7 +132,7 @@
       &.longpress {
         z-index: var(--card-y);
         filter: none;
-        transform: none;
+        transform: translate3d(0, calc(-1 * var(--card-y) * 21rem), 0);
 
         .current {
           border-right: none;

--- a/src/Leaderboard.svelte
+++ b/src/Leaderboard.svelte
@@ -263,26 +263,27 @@
 
   .type {
     position: relative;
+    top: 0;
     right: 25rem;
     color: white;
-    transition: top 200ms ease-in-out;
+    transition: transform 200ms ease-in-out;
 
     &.active:first-child {
-      top: 2.5rem;
+      transform: translateY(2.5rem);
     }
 
     &:not(.active):first-child {
-      top: -5rem;
       color: var(--color-dark);
+      transform: translateY(-5rem);
     }
 
     &.active:last-child {
-      top: -2.5rem;
+      transform: translateY(-2.5rem);
     }
 
     &:not(.active):last-child {
-      top: 6rem;
       color: var(--color-dark);
+      transform: translateY(6rem);
     }
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -291,17 +291,16 @@ function getMatchedFromCards(cards) {
  */
 function getMatchedCards(game, cards, matchedIndexes) {
   const counts = Array.from({ length: CORE.columns }, () => 0);
-  const getNextY = (nextX) =>
-    counts[nextX] +
-    cards
-      .filter(({ x }) => x === nextX)
-      .sort(({ y: y1 }, { y: y2 }) => y2 - y1)[0].y;
+  const maxY = Array.from({ length: CORE.columns }, () => 0);
+  for (let index = 0; index < cards.length; index++) {
+    const { x, y } = cards[index];
+    if (y > maxY[x]) maxY[x] = y;
+  }
   return cards.map((card, index) => {
     if (card.y < CORE.rows && matchedIndexes.has(index)) {
-      ++counts[card.x];
       return {
         x: card.x,
-        y: getNextY(card.x),
+        y: ++counts[card.x] + maxY[card.x],
         value: game.getNextCardValue(card.x),
         duration: 0,
       };


### PR DESCRIPTION
## Summary

This release smooths card fall animations on mobile by moving them from layout-based offsets to GPU-composited transforms, and refreshes the engine and dependencies behind the leaderboard and replay validation.

It also converts the leaderboard type switch to compositor-friendly transforms and speeds up the core match-collapse step, which replay validation relies on.

## Why

Card fall animations ran through `transition: bottom`, which forces a browser reflow on every animation frame. On low-end mobile Chrome, columns of falling cards visibly stuttered during match resolution.

## User-visible behavior

- Card falls animate with GPU-composited transforms — no per-frame reflow, smoother on mobile
- Leaderboard combos/scores type switch animates with transforms instead of layout offsets
- Match resolution and record replay validation run faster (core match collapse is now a single pass)

## Changed areas

- `src/Card.svelte` + `src/Leaderboard.svelte`: layout-property animations converted to `transform`
- `src/core.js`: `getMatchedCards` O(n² log n) → O(n), identical deterministic output
- `package.json`/`package-lock.json`: refreshed libp2p stack, Svelte, Vite, PostCSS; fixed high-severity `brace-expansion` advisory (0 vulnerabilities)
- `CHANGELOG.md`, `android/twa-manifest.json`: version 0.15.4 / versionCode 15004

## Risk Notes

- No gameplay logic changes: the core optimization preserves replay determinism (525/525 records re-validate)
- Dependency bumps are patch-level except Vite 8.1→8.2 (minor, same major); majors (`postcss-nested` 8, `stylelint-config-html` 2) deliberately deferred
- No migration/config changes required

## Validation

- `npm test` — 13 + 4 pass
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — success
- `npm run validate-records -- nodes/leaderboard/data.json` — 525 records, 0 failed
- `node android/compute-version-code.mjs` — 0.15.4 → 15004
