### PR TITLE
0.15.5: match animation smoothness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.15.5 Match Animation Smoothness
+
+- `Rendering`: Matched cards visibly blink again — the match flash was hidden by a rendering issue with filtered layers on composited cards and now draws directly on the card layer
+- `Rendering`: Matched cards dissolve with a soft blur-and-shrink effect instead of a hard cut
+- `Rendering`: Match highlight sliders animate with GPU transforms and opacity instead of per-frame clipping, removing the stutter during match resolution on mobile
+
 ## 0.15.4 Mobile Fall Animation Smoothness
 
 - `Rendering`: Card fall animations now use GPU-composited transforms instead of layout offsets, removing per-frame reflow on mobile — falling cards stay smooth during match resolution on low-end devices

--- a/android/twa-manifest.json
+++ b/android/twa-manifest.json
@@ -21,8 +21,8 @@
   "maskableIconUrl": "https://digifall.app/images/icon-512x512.png",
   "monochromeIconUrl": "https://digifall.app/images/icon-512x512.png",
   "splashScreenFadeOutDuration": 300,
-  "appVersion": "0.15.4",
-  "appVersionCode": 15004,
+  "appVersion": "0.15.5",
+  "appVersionCode": 15005,
   "signingKey": {
     "path": ".secrets/LLBLab.keystore",
     "alias": "LLBLab"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digifall",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -398,7 +398,7 @@
 
         &.blink {
           animation:
-            blink 200ms steps(2, end) 2,
+            slider-blink 200ms steps(2, end) 2,
             shrink-vertical 400ms ease 400ms forwards;
         }
 
@@ -416,7 +416,7 @@
 
         &.blink {
           animation:
-            blink 200ms steps(2, end) 2,
+            slider-blink 200ms steps(2, end) 2,
             shrink-horizontal 400ms ease 400ms forwards;
         }
 
@@ -447,23 +447,33 @@
     }
   }
 
-  @keyframes shrink-horizontal {
+  @keyframes slider-blink {
     from {
-      clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+      opacity: 1;
     }
 
     to {
-      clip-path: polygon(50% 0%, 50% 0%, 50% 100%, 50% 100%);
+      opacity: 0.2;
+    }
+  }
+
+  @keyframes shrink-horizontal {
+    from {
+      transform: scaleX(1);
+    }
+
+    to {
+      transform: scaleX(0.02);
     }
   }
 
   @keyframes shrink-vertical {
     from {
-      clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+      transform: scaleY(1);
     }
 
     to {
-      clip-path: polygon(0% 50%, 100% 50%, 100% 50%, 0% 50%);
+      transform: scaleY(0.02);
     }
   }
 </style>

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -64,6 +64,7 @@
       .current {
         animation: blink 200ms steps(2, end) 2;
         box-shadow: none;
+        filter: none;
       }
     }
 
@@ -209,11 +210,13 @@
 
     @keyframes fade-out {
       from {
-        clip-path: circle(100%);
+        filter: blur(0);
+        transform: translate3d(0, calc(-1 * var(--card-y) * 21rem), 0) scale(1);
       }
 
       to {
-        clip-path: circle(0%);
+        filter: blur(1rem);
+        transform: translate3d(0, calc(-1 * var(--card-y) * 21rem), 0) scale(0);
       }
     }
 


### PR DESCRIPTION
## Summary

This hotfix smooths the match animation on mobile: matched cards blink visibly again and dissolve softly, and the board highlight sliders no longer force per-frame repaints during match resolution.

It also removes the hidden rendering issue that made the card match flash invisible on composited card layers.

## Why

During match resolution, the highlight sliders animated `clip-path` on full-board layers with blend modes — a per-frame repaint cost that stuttered on low-end mobile. The card flash was simultaneously invisible because `background-color` animations inside a filtered sublayer of a composited card were dropped by the renderer.

## User-visible behavior

- Matched cards visibly blink again before disappearing (the white match flash is back)
- Matched cards dissolve with a soft blur-and-shrink effect
- Match highlight sliders animate via GPU transforms and opacity — no per-frame clipping repaints, smoother match resolution

## Changed areas

- `src/Card.svelte`: match flash now draws on the card layer directly (`filter: none` during blink); dissolve uses `scale` + `blur` keyframes
- `src/Board.svelte`: slider shrink animations converted from `clip-path` to `scaleX/scaleY`; slider flash converted from color to opacity keyframes

## Risk Notes

- No gameplay or deterministic logic changes — rendering only
- Blur filter repaints a small card area during the 400ms dissolve; acceptable on low-end devices, `steps()` discretization available if needed
- No migration/config changes required

## Validation

- `npm test` — 13 + 4 pass
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — success
- `npm run validate-records -- nodes/leaderboard/data.json` — 525 records, 0 failed
- `node android/compute-version-code.mjs` — 0.15.5 → 15005
